### PR TITLE
Implement more general method of policy gradients

### DIFF
--- a/policy.py
+++ b/policy.py
@@ -19,4 +19,6 @@ def softmax_policy(actions):
     for i in xrange(actions.shape[0]):
         selected_action[i, np.random.choice(selected_action.shape[1], 1, p = actions_flat[i])] = 1
     selected_action = np.reshape(selected_action, actions.shape)
-    return selected_action
+
+    ln_derivative = 1 / actions * selected_action
+    return selected_action, ln_derivative


### PR DESCRIPTION
Implement a more general method of policy gradients.

Although this is done without autograd for the loss function itself so derivatives must be found by hand with respect to output. This should then be passed to the model as targets.
